### PR TITLE
Type: change im --> img to fix undefine name

### DIFF
--- a/baiduApiVersion/GetTitleBaiduIos.py
+++ b/baiduApiVersion/GetTitleBaiduIos.py
@@ -34,7 +34,7 @@ token = res['access_token']
 
 
 c.screenshot('screenshot.png')
-im = Image.open("./screenshot.png")
+img = Image.open("./screenshot.png")
 
 region = img.crop((50, 350, 1000, 560)) # 坚果 pro1
 #region = img.crop((75, 315, 1167, 789)) # iPhone 7P


### PR DESCRIPTION
Without this change, __img__ on line 39 is an undefined name.  This change matches the Android code at https://github.com/Skyexu/TopSup/blob/master/baiduApiVersion/GetTitleBaiduAndroid.py#L22

flake8 testing of https://github.com/Skyexu/TopSup

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./baiduApiVersion/GetTitleBaiduIos.py:39:10: F821 undefined name 'img'
region = img.crop((50, 350, 1000, 560)) # 坚果 pro1
         ^
1     F821 undefined name 'img'
```